### PR TITLE
[Bugfix] Console error in checkout and order confirmation page 

### DIFF
--- a/blocks/commerce-checkout/commerce-checkout.js
+++ b/blocks/commerce-checkout/commerce-checkout.js
@@ -14,6 +14,8 @@ import { render as provider } from '@dropins/storefront-checkout/render.js';
 // Drop-in Containers
 import Checkout from '@dropins/storefront-checkout/containers/Checkout.js';
 
+import { getConfigValue } from '../../scripts/configs.js';
+
 export default async function decorate(block) {
   // If cartId is cached in session storage, use
   // otherwise, checkout drop-in will look for one in the event-bus
@@ -21,6 +23,12 @@ export default async function decorate(block) {
 
   // Initialize Drop-ins
   initializers.register(checkout.initialize, {});
+
+  // Set Fetch Endpoint (Service) if not yet set
+  const gqlConfig = checkout.getConfig();
+  if (!gqlConfig.endpoint) {
+    checkout.setEndpoint(await getConfigValue('commerce-core-endpoint'));
+  }
 
   // Listen for order confirmation and redirect to order confirmation page
   events.on('checkout/order', (data) => {

--- a/blocks/commerce-order-confirmation/commerce-order-confirmation.js
+++ b/blocks/commerce-order-confirmation/commerce-order-confirmation.js
@@ -13,9 +13,17 @@ import { render as provider } from '@dropins/storefront-order-confirmation/rende
 // Drop-in Containers
 import OrderConfirmation from '@dropins/storefront-order-confirmation/containers/OrderConfirmation.js';
 
+import { getConfigValue } from '../../scripts/configs.js';
+
 export default async function decorate(block) {
   // Initialize Drop-ins
   initializers.register(orderConfirmation.initialize, {});
+
+  // Set Fetch Endpoint (Service) if not yet set
+  const gqlConfig = orderConfirmation.getConfig();
+  if (!gqlConfig.endpoint) {
+    orderConfirmation.setEndpoint(await getConfigValue('commerce-core-endpoint'));
+  }
 
   const params = new URLSearchParams(window.location.search);
   const orderRef = params.get('orderRef');


### PR DESCRIPTION
Fixes an intermittent bug that causes an error to be logged in the console when a visitor visits the checkout or order confirmation page for the first time.

Can be replicated by clearing the cache or using incognito mode.

This happens when the checkout or order confirmation dropin renders before the graphql endpoint has been set globally for the fetch-graphql package.

URL for testing:

- https://bugfix_null-endpoint2--boilerplate-commerce-dropins--jcalcaben.hlx.page/
