### PR TITLE
[dnm]: aep collection example

### DIFF
--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -38,7 +38,7 @@ export default async function decorate(block) {
 
   // Render Containers
 
-  return productRenderer.render(ProductDetails, {
+  const render = await productRenderer.render(ProductDetails, {
     sku: getSkuFromUrl(),
     carousel: {
       controls: 'dots', // 'thumbnailsColumn', 'thumbnailsRow', 'dots'
@@ -85,4 +85,10 @@ export default async function decorate(block) {
       },
     },
   })(block);
+  // TODO: should this be here or somewhere else?
+  window.adobeDataLayer = window.adobeDataLayer || [];
+  window.adobeDataLayer.push((dl) => {
+    dl.push({ event: 'page-view', eventInfo: { ...dl.getState() } });
+  });
+  return render;
 }

--- a/blocks/product-details/product-details.js
+++ b/blocks/product-details/product-details.js
@@ -38,7 +38,7 @@ export default async function decorate(block) {
 
   // Render Containers
 
-  const render = await productRenderer.render(ProductDetails, {
+  return productRenderer.render(ProductDetails, {
     sku: getSkuFromUrl(),
     carousel: {
       controls: 'dots', // 'thumbnailsColumn', 'thumbnailsRow', 'dots'
@@ -85,10 +85,4 @@ export default async function decorate(block) {
       },
     },
   })(block);
-  // TODO: should this be here or somewhere else?
-  window.adobeDataLayer = window.adobeDataLayer || [];
-  window.adobeDataLayer.push((dl) => {
-    dl.push({ event: 'page-view', eventInfo: { ...dl.getState() } });
-  });
-  return render;
 }

--- a/scripts/cookie.js
+++ b/scripts/cookie.js
@@ -1,0 +1,12 @@
+function getCookie(key) {
+  const cookies = document.cookie.split(';');
+  for (let i = 0; i < cookies.length; i++) {
+    const cookie = cookies[i].trim();
+    if (cookie.startsWith(`${key}=`)) {
+      return cookie.substring(key.length + 1);
+    }
+  }
+  return null;
+}
+
+export default getCookie;

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -26,10 +26,21 @@ const config = {
   storefrontTemplate: 'Franklin',
 };
 
-window.adobeDataLayer.push(
+// TODO: use from config, not hardcode.
+const imsOrgId = 'DEDB2A52641B1D460A495F8E@AdobeOrg'; // await getConfigValue('commerce-ims-org');
+const datastreamId = 'fedf2de7-16d7-482b-92e0-f56fba88c532'; // await getConfigValue('commerce-datastream-id'); //
+const shouldEnableAEP = imsOrgId && datastreamId;
+
+const payload = [
   { storefrontInstanceContext: config },
-  { eventForwardingContext: { commerce: true, aep: false } },
-);
+  { eventForwardingContext: { commerce: true, aep: shouldEnableAEP } },
+];
+
+if (shouldEnableAEP) {
+  payload.push({ aepContext: { imsOrgId, datastreamId, webSdkName: '' } });
+}
+
+window.adobeDataLayer.push(...payload);
 
 // Load events SDK and collector
 import('./commerce-events-sdk.js');

--- a/scripts/dropins.js
+++ b/scripts/dropins.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unresolved */
 // Drop-in Tools
 import { events } from '@dropins/tools/event-bus.js';
-import { setEndpoint } from '@dropins/tools/fetch-graphql.js';
+import { setEndpoint, setFetchGraphQlHeaders } from '@dropins/tools/fetch-graphql.js';
 import { initializers } from '@dropins/tools/initializer.js';
 
 // Drop-ins
@@ -9,10 +9,19 @@ import * as cart from '@dropins/storefront-cart/api.js';
 
 // Libs
 import { getConfigValue } from './configs.js';
+import getCookie from './cookie.js';
 
 export default async function initializeDropins() {
   // Set Fetch Endpoint (Global)
   setEndpoint(await getConfigValue('commerce-core-endpoint'));
+
+  // TODO: Do we need to apply this in other dropin blocks such as minicart/cart or checkout?
+  const aepCookie = getCookie('aep-segments-membership');
+  if (aepCookie) {
+    setFetchGraphQlHeaders({
+      'aep-segments-membership': aepCookie,
+    });
+  }
 
   // Initializers (Global)
   initializers.register(cart.initialize, {});


### PR DESCRIPTION
Shows how we might use the Storefront Event Collector to also emit to AEP to power "real time personalization" such as cart rule pricing.

What this does is:

1) Emits page view event on pdp.
2) Sets AEP context in delayed.js (if proper config found)
3) Sets GQL header if segment cookie is found.

If configured properly in backend, this should start returning segment-specific data, such as customer-specific cart pricing. You should see a special cart price shown.

Test URLs:
- https://aep-collection--boilerplate-commerce-dropins--hlxsites.hlx.live/
- https://aep-collection--boilerplate-commerce-dropins--hlxsites.hlx.live/products/crown-summit-backpack/24-MB03
