### PR TITLE
Fixed dropin mount on prerendered documents

### DIFF
--- a/scripts/dropins.js
+++ b/scripts/dropins.js
@@ -70,14 +70,19 @@ export default async function initializeDropins() {
   // After load or reload page we check token
   const token = getUserTokenCookie();
 
-  // Mount all registered drop-ins
-  if (document.readyState === 'complete') {
+  // Handle page load
+  const mount = () => {
     initializers.mount();
     events.emit('authenticated', !!token);
+  };
+
+  // Mount all registered drop-ins
+  if (document.readyState === 'complete') {
+    mount();
   } else {
-    window.addEventListener('load', () => {
-      initializers.mount();
-      events.emit('authenticated', !!token);
-    });
+    // Handle on prerendering document activated
+    document.addEventListener('prerenderingchange', mount);
+    // Handle on page load
+    window.addEventListener('load', mount);
   }
 }


### PR DESCRIPTION
This fixes the issue of dropins not getting mounted when navigating to a page that has been pre-rendered by the `speculationrules` API.

Test URLs:
- Before: https://main--boilerplate-commerce-dropins--hlxsites.hlx.live/
- After: https://fix-prerender-mounts--boilerplate-commerce-dropins--hlxsites.hlx.live/
