### PR TITLE
Asynchronous auth blocks rendering

### DIFF
--- a/blocks/commerce-confirm-account/commerce-confirm-account.js
+++ b/blocks/commerce-confirm-account/commerce-confirm-account.js
@@ -7,13 +7,13 @@ import { render as authRenderer } from '@dropins/storefront-auth/render.js';
 import { Button } from '@dropins/tools/components.js';
 import { getCookie } from '../../scripts/configs.js';
 
-export default function decorate(block) {
+export default async function decorate(block) {
   const isAuthenticated = !!getCookie('auth_dropin_user_token');
 
   if (isAuthenticated) {
     window.location.href = '/customer/account';
   } else {
-    authRenderer.render(SignIn, {
+    await authRenderer.render(SignIn, {
       enableEmailConfirmation: true,
       routeForgotPassword: () => '/customer/forgotpassword',
       slots: {

--- a/blocks/commerce-create-account/commerce-create-account.js
+++ b/blocks/commerce-create-account/commerce-create-account.js
@@ -4,13 +4,13 @@ import { SignUp } from '@dropins/storefront-auth/containers/SignUp.js';
 import { render as authRenderer } from '@dropins/storefront-auth/render.js';
 import { getCookie } from '../../scripts/configs.js';
 
-export default function decorate(block) {
+export default async function decorate(block) {
   const isAuthenticated = !!getCookie('auth_dropin_user_token');
 
   if (isAuthenticated) {
     window.location.href = '/customer/account';
   } else {
-    authRenderer.render(SignUp, {
+    await authRenderer.render(SignUp, {
       hideCloseBtnOnEmailConfirmation: true,
       routeSignIn: () => '/customer/login',
       routeRedirectOnSignIn: () => '/customer/account',

--- a/blocks/commerce-create-password/commerce-create-password.js
+++ b/blocks/commerce-create-password/commerce-create-password.js
@@ -7,13 +7,13 @@ import { Button } from '@dropins/tools/components.js';
 import * as authApi from '@dropins/storefront-auth/api.js';
 import { getCookie } from '../../scripts/configs.js';
 
-export default function decorate(block) {
+export default async function decorate(block) {
   const isAuthenticated = !!getCookie('auth_dropin_user_token');
 
   if (isAuthenticated) {
     window.location.href = '/customer/account';
   } else {
-    authRenderer.render(UpdatePassword, {
+    await authRenderer.render(UpdatePassword, {
       routeWrongUrlRedirect: () => '/customer/login',
       slots: {
         SuccessNotification: (ctx) => {

--- a/blocks/commerce-forgot-password/commerce-forgot-password.js
+++ b/blocks/commerce-forgot-password/commerce-forgot-password.js
@@ -5,13 +5,13 @@ import { render as authRenderer } from '@dropins/storefront-auth/render.js';
 import { events } from '@dropins/tools/event-bus.js';
 import { getCookie } from '../../scripts/configs.js';
 
-export default function decorate(block) {
+export default async function decorate(block) {
   const isAuthenticated = !!getCookie('auth_dropin_user_token');
 
   if (isAuthenticated) {
     window.location.href = '/customer/account';
   } else {
-    authRenderer.render(ResetPassword, {
+    await authRenderer.render(ResetPassword, {
       routeSignIn: () => '/customer/login',
     })(block);
   }

--- a/blocks/commerce-login/commerce-login.js
+++ b/blocks/commerce-login/commerce-login.js
@@ -4,13 +4,13 @@ import { SignIn } from '@dropins/storefront-auth/containers/SignIn.js';
 import { render as authRenderer } from '@dropins/storefront-auth/render.js';
 import { getCookie } from '../../scripts/configs.js';
 
-export default function decorate(block) {
+export default async function decorate(block) {
   const isAuthenticated = !!getCookie('auth_dropin_user_token');
 
   if (isAuthenticated) {
     window.location.href = '/customer/account';
   } else {
-    authRenderer.render(SignIn, {
+    await authRenderer.render(SignIn, {
       routeForgotPassword: () => '/customer/forgotpassword',
       routeRedirectOnSignIn: () => '/customer/account',
     })(block);


### PR DESCRIPTION
Refactored auth blocks to render containers asynchronously.

Test URLs:
- Before: https://main--boilerplate-commerce-dropins--hlxsites.hlx.live/
- After: https://adjust-auth-blocks-rendering--boilerplate-commerce-dropins--hlxsites.hlx.live/
