### PR TITLE
[chore] Fix incorrect environment string for storefrontInstance context

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -12,7 +12,7 @@ sampleRUM('cwv');
 if (getConsent('commerce-collection')) {
   const config = {
     environmentId: await getConfigValue('commerce-environment-id'),
-    environment: await getConfigValue('commerce-environment') === 'Production' ? 'prod' : 'non-prod',
+    environment: await getConfigValue('commerce-environment') === 'Production' ? 'Production' : 'Testing',
     storeUrl: await getConfigValue('commerce-store-url'),
     websiteId: parseInt(await getConfigValue('commerce-website-id'), 10),
     websiteCode: await getConfigValue('commerce-website-code'),


### PR DESCRIPTION
Incorrect value was being set, because the schema/docs also had the incorrect value when we wrote this.

See related fix to schema: https://github.com/adobe/commerce-events/pull/159/files