### PR TITLE
fix incorrect env value setting in eventing config

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -12,7 +12,7 @@ sampleRUM('cwv');
 if (getConsent('commerce-collection')) {
   const config = {
     environmentId: await getConfigValue('commerce-environment-id'),
-    environment: await getConfigValue('commerce-environment') === 'Production' ? 'prod' : 'non-prod',
+    environment: await getConfigValue('commerce-environment') === 'Production' ? 'Production' : 'Testing',
     storeUrl: await getConfigValue('commerce-store-url'),
     websiteId: parseInt(await getConfigValue('commerce-website-id'), 10),
     websiteCode: await getConfigValue('commerce-website-code'),


### PR DESCRIPTION
Schema was wrong when we first wrote this. Should be `Production` or `Testing`

https://github.com/adobe/commerce-events/blob/0621d751adad5be02feeb5e066f7816747a78514/packages/storefront-events-sdk/src/types/schemas/storefrontInstance.ts#L5